### PR TITLE
Bring Climate entity up to date

### DIFF
--- a/custom_components/melview/climate.py
+++ b/custom_components/melview/climate.py
@@ -23,22 +23,18 @@
 import logging
 
 from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_FAN_ONLY,
-    SUPPORT_FAN_MODE,
-    SUPPORT_TARGET_TEMPERATURE
+    HVACMode,
+    ClimateEntityFeature
 )
+
+
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.const import (
+    UnitOfTemperature,
     ATTR_TEMPERATURE,
     PRECISION_HALVES,
     PRECISION_WHOLE,
-    STATE_OFF,
-    TEMP_CELSIUS
+    STATE_OFF
 )
 
 from .melview import MelViewAuthentication, MelView, MODE
@@ -49,7 +45,7 @@ DOMAIN = 'melview'
 REQUIREMENTS = ['requests']
 DEPENDENCIES = []
 
-HVAC_MODES = [HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT, HVACMode.OFF]
 
 
 # ---------------------------------------------------------------
@@ -58,12 +54,13 @@ class MelViewClimate(ClimateEntity):
     """ Melview handler for HomeAssistants
     """
     def __init__(self, device):
+        self._enable_turn_on_off_backwards_compatibility = False
         self._device = device
 
         self._name = 'MelView {}'.format(device.get_friendly_name())
         self._unique_id = device.get_id()
 
-        self._operations_list = [x for x in MODE] + [HVAC_MODE_OFF]
+        self._operations_list = [x for x in MODE] + [HVACMode.OFF]
         self._speeds_list = [x for x in self._device.fan_keyed]
 
         self._precision = PRECISION_WHOLE
@@ -150,7 +147,7 @@ class MelViewClimate(ClimateEntity):
         """ Let HASS know feature support
             TODO: Handle looking at the device features?
         """
-        return (SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE)
+        return (ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF)
 
 
     @property
@@ -185,7 +182,7 @@ class MelViewClimate(ClimateEntity):
     def temperature_unit(self):
         """ Define unit for temperature
         """
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
 
     @property

--- a/custom_components/melview/manifest.json
+++ b/custom_components/melview/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "melview",
   "name": "MelView",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "config_flow": true,
   "documentation": "https://github.com/haggis663/ha-melview",
   "issue_tracker": "https://github.com/haggis663/ha-melview/issues",

--- a/custom_components/melview/melview.py
+++ b/custom_components/melview/melview.py
@@ -30,12 +30,7 @@ from .const import DOMAIN, CONF_LOCAL, APPVERSION, HEADERS, APIVERSION
 
 
 from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_FAN_ONLY
+    HVACMode
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,11 +48,11 @@ LOCAL_DATA = """<?xml version="1.0" encoding="UTF-8"?>
 # ---------------------------------------------------------------
 
 MODE = {
-    HVAC_MODE_AUTO: 8,
-    HVAC_MODE_HEAT: 1,
-    HVAC_MODE_COOL: 3,
-    HVAC_MODE_DRY: 2,
-    HVAC_MODE_FAN_ONLY: 7
+    HVACMode.AUTO: 8,
+    HVACMode.HEAT: 1,
+    HVACMode.COOL: 3,
+    HVACMode.DRY: 2,
+    HVACMode.FAN_ONLY: 7
 }
 
 FANSTAGES = {
@@ -509,27 +504,27 @@ class MelViewDevice:
         """ Get the set mode.
         """
         if not self._is_info_valid():
-            return HVAC_MODE_AUTO
+            return HVACMode.AUTO
 
         if self.is_power_on():
             for key, val in MODE.items():
                 if self._json['setmode'] == val:
                     return key
 
-        return HVAC_MODE_AUTO
+        return HVACMode.AUTO
 
     async def async_get_mode(self):
         """ Get the set mode.
         """
         if not await self.async_is_info_valid():
-            return HVAC_MODE_AUTO
+            return HVACMode.AUTO
 
         if await self.async_is_power_on():
             for key, val in MODE.items():
                 if self._json['setmode'] == val:
                     return key
 
-        return HVAC_MODE_AUTO
+        return HVACMode.AUTO
 
 
     def get_zone(self, zoneid):


### PR DESCRIPTION
Update enums and turn_on/turn_off features

Updated references to the following enums, pointing them to their new respective HVACMode., ClimateEntityFeature., or UnitOfTemperature. counterpart:
HVAC_MODE_OFF,
HVAC_MODE_AUTO,
HVAC_MODE_COOL,
HVAC_MODE_DRY,
HVAC_MODE_HEAT,
HVAC_MODE_FAN_ONLY,
SUPPORT_FAN_MODE,
SUPPORT_TARGET_TEMPERATURE,
TEMP_CELSIUS

Support new ClimateEntityFeature.TURN_ON and *.TURN_OFF functionality

References:
https://developers.home-assistant.io/blog/2022/05/03/constants-deprecations/ 
https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/

The integration no longer throws warnings in HA logs. This is my first time with Python and pushing a PR to someone elses repo, so feel free to hack at it :) 