### PR TITLE
Added initial support for reading Lossney devices through Melview

### DIFF
--- a/custom_components/melview/climate.py
+++ b/custom_components/melview/climate.py
@@ -37,7 +37,7 @@ from homeassistant.const import (
     STATE_OFF
 )
 
-from .melview import MelViewAuthentication, MelView, MODE
+from .melview import MODE_ERV, UNIT_TYPE_ERV, MelViewAuthentication, MelView, MODE_ATA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +46,6 @@ REQUIREMENTS = ['requests']
 DEPENDENCIES = []
 
 HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT, HVACMode.OFF]
-
 
 # ---------------------------------------------------------------
 
@@ -59,8 +58,14 @@ class MelViewClimate(ClimateEntity):
 
         self._name = 'MelView {}'.format(device.get_friendly_name())
         self._unique_id = device.get_id()
-
-        self._operations_list = [x for x in MODE] + [HVACMode.OFF]
+    
+        if self._device.get_unit_type() == UNIT_TYPE_ERV:
+            self._operations_list = []
+            self.preset_list = [x for x in MODE_ERV]
+        else:
+            self._operations_list = [x for x in MODE_ATA] + [HVACMode.OFF]
+            self.preset_list = None
+        
         self._speeds_list = [x for x in self._device.fan_keyed]
 
         self._precision = PRECISION_WHOLE
@@ -73,6 +78,7 @@ class MelViewClimate(ClimateEntity):
         self._target_temp = self._device.get_temperature()
 
         self._mode = self._device.get_mode()
+        self._preset = self._device.get_preset()
         self._speed = self._device.get_speed()
 
         self._state = STATE_OFF
@@ -96,6 +102,7 @@ class MelViewClimate(ClimateEntity):
         self._target_temp = self._device.get_temperature()
 
         self._mode = self._device.get_mode()
+        self._preset = self._device.get_preset()
         self._speed = self._device.get_speed()
 
         self._state = self._mode
@@ -120,6 +127,7 @@ class MelViewClimate(ClimateEntity):
         self._target_temp = self._device.get_temperature()
 
         self._mode = await self._device.async_get_mode()
+        self._preset = await self._device.async_get_preset()
         self._speed = await self._device.async_get_speed()
 
         self._state = self._mode
@@ -147,8 +155,10 @@ class MelViewClimate(ClimateEntity):
         """ Let HASS know feature support
             TODO: Handle looking at the device features?
         """
-        return (ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF)
-
+        if self._device.get_unit_type() == UNIT_TYPE_ERV:
+          return (ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF)
+        else:
+          return (ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF)
 
     @property
     def should_poll(self):
@@ -236,6 +246,18 @@ class MelViewClimate(ClimateEntity):
         """
         return self._operations_list
 
+    @property
+    def preset_mode(self):
+        """ Get the current preset mode
+        """
+        return self._preset
+
+    @property
+    def preset_modes(self):
+        """ Get possible preset modes
+        """
+        return self.preset_list
+
 
     @property
     def fan_mode(self):
@@ -306,6 +328,14 @@ class MelViewClimate(ClimateEntity):
         elif self._device.set_mode(mode):
             self._mode = mode
             self._state = mode
+    
+    def set_preset_mode(self, preset_mode):
+        """Set new target preset mode."""
+        _LOGGER.warning("Setting preset mode not implemented yet")
+
+    async def async_set_preset_mode(self, preset_mode):
+        """Set new target preset mode."""
+        _LOGGER.warning("Setting preset mode not implemented yet")
 
     async def async_turn_on(self) ->None:
         """ Turn on the unit

--- a/custom_components/melview/climate.py
+++ b/custom_components/melview/climate.py
@@ -331,11 +331,13 @@ class MelViewClimate(ClimateEntity):
     
     def set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
-        _LOGGER.warning("Setting preset mode not implemented yet")
+        if self._device.set_preset(preset_mode):
+            self._preset = preset_mode
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
-        _LOGGER.warning("Setting preset mode not implemented yet")
+        if await self._device.async_set_preset(preset_mode):
+            self._preset = preset_mode
 
     async def async_turn_on(self) ->None:
         """ Turn on the unit

--- a/custom_components/melview/melview.py
+++ b/custom_components/melview/melview.py
@@ -721,6 +721,41 @@ class MelViewDevice:
             _LOGGER.error('mode %d not supported', mode)
             return False
         return self._send_command('MD{}'.format(MODE_ATA[mode]))
+    
+    def set_preset(self, preset):
+        """ Set operating preset (for ERV units).
+        """
+        if self.unit_type != UNIT_TYPE_ERV:
+            _LOGGER.error('presets not supported for non-ERV units')
+            return False
+
+        if not self.is_power_on():
+            # Try turn on the unit if off.
+            if not self.power_on():
+                return False
+
+        if preset not in MODE_ERV.keys():
+            _LOGGER.error('preset %s not supported', preset)
+            return False
+        return self._send_command('MD{}'.format(MODE_ERV[preset]))
+    
+    async def async_set_preset(self, preset):
+        """ Set operating preset (for ERV units).
+        """
+        if self.unit_type != UNIT_TYPE_ERV:
+            _LOGGER.error('presets not supported for non-ERV units')
+            return False
+
+        if not await self.async_is_power_on():
+            # Try turn on the unit if off.
+            if not await self.async_power_on():
+                return False
+
+        if preset not in MODE_ERV.keys():
+            _LOGGER.error('preset %s not supported', preset)
+            return False
+
+        return await self.async_send_command('MD{}'.format(MODE_ERV[preset]))
 
     async def async_enable_zone(self, zoneid):
         """ Turn on a zone.

--- a/custom_components/melview/melview.py
+++ b/custom_components/melview/melview.py
@@ -47,13 +47,29 @@ LOCAL_DATA = """<?xml version="1.0" encoding="UTF-8"?>
 
 # ---------------------------------------------------------------
 
-MODE = {
+# This seems to be a standard heat pump
+MODE_ATA = {
     HVACMode.AUTO: 8,
     HVACMode.HEAT: 1,
     HVACMode.COOL: 3,
     HVACMode.DRY: 2,
     HVACMode.FAN_ONLY: 7
 }
+
+# This section is for a Lossney ERV (Energy Recovery Ventilator)
+# Since it's not possible to add custom climate modes in home assistant,
+# all Lossney modes are modelled as presets: https://developers.home-assistant.io/docs/core/entity/climate?_highlight=climate#hvac-modes`
+PRESET_AUTO = "Auto"
+PRESET_LOSSNAY = "Lossnay"
+PRESET_BYPASS = "Bypass"
+
+MODE_ERV = {
+    PRESET_AUTO: 3,
+    PRESET_LOSSNAY: 1,
+    PRESET_BYPASS: 7,
+}
+
+UNIT_TYPE_ERV = "ERV"
 
 FANSTAGES = {
     1: {5: "On"},
@@ -153,6 +169,7 @@ class MelViewDevice:
 
         self._caps = None
         self._localip = localcontrol
+        self.unit_type = None
 
         self._info_lease_seconds = 30  # Data lasts for 30s.
         self._json = None
@@ -188,6 +205,8 @@ class MelViewDevice:
                 self.fan = FANSTAGES[self._caps['fanstage']]
             if 'hasautofan' in self._caps and self._caps['hasautofan'] == 1:
                 self.fan[0] = 'auto'
+            if self._caps['unittype']:
+                self.unit_type = self._caps['unittype']
             self.fan_keyed = {value: key for key, value in self.fan.items()}
             return True
         if req.status_code == 401 and retry:
@@ -244,6 +263,8 @@ class MelViewDevice:
                 self.fan = FANSTAGES[self._caps['fanstage']]
             if 'hasautofan' in self._caps and self._caps['hasautofan'] == 1:
                 self.fan[0] = 'auto'
+            if self._caps['unittype']:
+                self.unit_type = self._caps['unittype']
             self.fan_keyed = {value: key for key, value in self.fan.items()}
             return True
         if req.status == 401 and retry:
@@ -503,35 +524,78 @@ class MelViewDevice:
     def get_mode(self):
         """ Get the set mode.
         """
+        if self.unit_type == UNIT_TYPE_ERV:
+            return None
+
         if not self._is_info_valid():
             return HVACMode.AUTO
 
         if self.is_power_on():
-            for key, val in MODE.items():
+            for key, val in MODE_ATA.items():
                 if self._json['setmode'] == val:
                     return key
 
         return HVACMode.AUTO
+    
+    def get_preset(self):
+        """ Get the set preset (for ERV units).
+        """
+        if self.unit_type != UNIT_TYPE_ERV:
+            return None
+
+        if not self._is_info_valid():
+            return PRESET_AUTO
+
+        if self.is_power_on():
+            for key, val in MODE_ERV.items():
+                if self._json['setmode'] == val:
+                    return key
+
+        return PRESET_AUTO
+
 
     async def async_get_mode(self):
         """ Get the set mode.
         """
+        if self.unit_type == UNIT_TYPE_ERV:
+            return None
+
         if not await self.async_is_info_valid():
             return HVACMode.AUTO
 
         if await self.async_is_power_on():
-            for key, val in MODE.items():
+            for key, val in MODE_ATA.items():
                 if self._json['setmode'] == val:
                     return key
 
         return HVACMode.AUTO
 
+    async def async_get_preset(self):
+        """ Get the set preset (for ERV units).
+        """
+        if self.unit_type != UNIT_TYPE_ERV:
+            return None
+
+        if not await self.async_is_info_valid():
+            return PRESET_AUTO
+
+        if await self.async_is_power_on():
+            for key, val in MODE_ERV.items():
+                if self._json['setmode'] == val:
+                    return key
+
+        return PRESET_AUTO
 
     def get_zone(self, zoneid):
         return self._zones.get(zoneid)
 
     def get_zones(self):
         return self._zones.values()
+
+    def get_unit_type(self):
+        """ Get the unit type.
+        """
+        return self.unit_type
 
     def is_power_on(self):
         """ Check unit is on.
@@ -553,8 +617,8 @@ class MelViewDevice:
         """ Set the target temperature.
         """
         mode = self.get_mode()
-        min_temp = self._caps['max'][str(MODE[mode])]['min']
-        max_temp = self._caps['max'][str(MODE[mode])]['max']
+        min_temp = self._caps['max'][str(MODE_ATA[mode])]['min']
+        max_temp = self._caps['max'][str(MODE_ATA[mode])]['max']
         if temperature < min_temp:
             _LOGGER.error('temp %.1f lower than min %d for mode %d',
                           temperature, min_temp, mode)
@@ -571,9 +635,9 @@ class MelViewDevice:
         mode = await self.async_get_mode()
         min_temp =19
         max_temp=28
-        if str(MODE[mode]) in self._caps['max']:
-            min_temp = self._caps['max'][str(MODE[mode])]['min']
-            max_temp = self._caps['max'][str(MODE[mode])]['max']
+        if str(MODE_ATA[mode]) in self._caps['max']:
+            min_temp = self._caps['max'][str(MODE_ATA[mode])]['min']
+            max_temp = self._caps['max'][str(MODE_ATA[mode])]['max']
         else:
             min_temp = self._caps['max']['8']['min']
             max_temp = self._caps['max']['8']['max']
@@ -630,10 +694,10 @@ class MelViewDevice:
         if mode != 'Cool' and ('hascoolonly' in self._caps and self._caps['hascoolonly'] == 1):
             _LOGGER.error('only cool mode supported')
             return False
-        if mode not in MODE.keys():
+        if mode not in MODE_ATA.keys():
             _LOGGER.error('mode %d not supported', mode)
             return False
-        return await self.async_send_command('MD{}'.format(MODE[mode]))
+        return await self.async_send_command('MD{}'.format(MODE_ATA[mode]))
 
 
     def set_mode(self, mode):
@@ -653,10 +717,10 @@ class MelViewDevice:
         if mode != 'Cool' and ('hascoolonly' in self._caps and self._caps['hascoolonly'] == 1):
             _LOGGER.error('only cool mode supported')
             return False
-        if mode not in MODE.keys():
+        if mode not in MODE_ATA.keys():
             _LOGGER.error('mode %d not supported', mode)
             return False
-        return self._send_command('MD{}'.format(MODE[mode]))
+        return self._send_command('MD{}'.format(MODE_ATA[mode]))
 
     async def async_enable_zone(self, zoneid):
         """ Turn on a zone.


### PR DESCRIPTION
This adds the ability to change how the Climate entity is reported for an ERV (Energy Recovery Ventilation) system. These are marketed as Lossney systems. An ERV does not have climate modes in the traditional sense, but has three options "Lossney", "Auto" and "Bypass". ERV Systems also do not support a target temperature that is settable by the user so that capability is also disabled.

Since a Climate Entity doesn't permit adding custom modes, and only one of the modes (and off) maps to an actual Climate Mode, I chose to disable modes entirely for ERV and model these as Presets (this is the suggest way in the HA Dev docs: <https://developers.home-assistant.io/docs/core/entity/climate/?_highlight=climate#hvac-modes>). 

An ERV system is defined by the `unittype` attribute in the `unitcapabilites.aspx` API. 

The modes have a very different mapping and those are mapped to Presets, which are then returned back into HA. I've not currently implemented the ability to change these though HA.

Longer term it would be nice to be able to set the presets through HA, and to expose the other temperatures that the API exposes as additional sensors on the MelView device.

For reference here is a screenshot of the MelView UI for a Lossney system:

<img width="622" height="707" alt="image" src="https://github.com/user-attachments/assets/e13fcf43-1444-4a58-8f24-5d6c0f747f58" />
